### PR TITLE
Add support for .net 4.5

### DIFF
--- a/src/Managed.Reflection/project.json
+++ b/src/Managed.Reflection/project.json
@@ -7,12 +7,16 @@
         "keyFile": "../../../Managed.Reflection.snk"
     },
     "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "System.Security.Cryptography.Algorithms": "4.2.0",
-        "System.Security.Cryptography.Csp": "4.0.0"
     },
     "frameworks": {
-        "netstandard1.3": { }
+        "netstandard1.3": {
+            "dependencies": {
+                "NETStandard.Library": "1.6.0",
+                "System.Security.Cryptography.Algorithms": "4.2.0",
+                "System.Security.Cryptography.Csp": "4.0.0"
+            }
+        },
+        "net45": {}
     },
     "packOptions": {
         "summary": "Managed implementation of System.Reflection[.Emit]",


### PR DESCRIPTION
This commit add .net 4.5 as an additional compilation target.

This allows the library to be used by other libraries targeting 4.5 as well as allows .net4\* libraries to consume Managed.Reflection without having to pull in all the references assemblies which are now added . 

This means 
- 17 less dlls to ship and copy with the final application! 
- 47 less packages added to packages.config for consuming libraries

Background:
I was trying out the library in order it could be used to replace som reflection against "reflection only" assemblies for the code generation in OpenRiaService, but using the current packaging this is a  no-go.
